### PR TITLE
Update cookbook links to point to css/ subdirectory

### DIFF
--- a/cookbook/_assets/lms-css.js
+++ b/cookbook/_assets/lms-css.js
@@ -5,10 +5,10 @@ function getFallbackCssUrl() {
   const { origin, pathname } = window.location
 
   if (pathname.includes('/staging/')) {
-    return `${origin}/canvas-css/staging/canvas-style.css`
+    return `${origin}/canvas-css/staging/css/canvas-style.css`
   }
 
-  return `${origin}/canvas-css/dist/canvas-style.css`
+  return `${origin}/canvas-css/dist/css/canvas-style.css`
 }
 
 if (import.meta.env.DEV) {


### PR DESCRIPTION
@sophiazumich  remember when we messed with the css link in canvas? that also had an effect here, it didnt get updated 😅 
this fixes that